### PR TITLE
Add docker compose example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 sudo: required
 services:
   - docker
+env:
+  DOCKER_COMPOSE_VERSION: 1.5.2
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
 language: python
 python:
     - "2.7"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ The example code demonstrates how to use [pytest](http://pytest.org/latest/)
 and [docker-py](https://github.com/docker/docker-py#docker-py).
 
 In this repo:
-* [test_screencast.py](./test_screencast.py) - Example tests, one that succceds,
-                                               and one that fails.
+* [test_screencast.py](./test_screencast.py) - Example tests:
+  * `test__example_service` - Successful test that runs once using docker-py
+    to start containers, and once using docker-compose
+  * `test_error` - When not skipped, demonstrates getting log output when
+                   the test fails
 * [conftest.py](./conftest.py) - pytest plugin to run our example service
 * [service](./service) - An example HTTP service, to be run by the tests
 
@@ -51,8 +54,7 @@ will rely on the environment variables set when you run
 
 1. Build the example image:
   ```bash
-  pushd service
-  docker build -t service .
+  docker-compose build
   popd
   ```
   

--- a/conftest.py
+++ b/conftest.py
@@ -90,8 +90,7 @@ def example_container_with_docker_compose():
 
     docker_client = _docker_client()
     container_info = docker_client.inspect_container("examplecontainer")
-    # Get the IP address using the network docker-compose automatically creates
-    yield container_info["NetworkSettings"]["Networks"]["pytestdockerpy_default"]["IPAddress"]
+    yield container_info["NetworkSettings"]["IPAddress"]
 
     subprocess.check_output(shlex.split("docker-compose down"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,5 @@
-version: '2'
-services:
-  example:
-    image: service
-    build: ./service
-    container_name: examplecontainer
-    labels:
-      - "pytest_docker_log"
+example:
+  build: ./service
+  container_name: examplecontainer
+  labels:
+    - "pytest_docker_log"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  example:
+    image: service
+    build: ./service
+    container_name: examplecontainer
+    labels:
+      - "pytest_docker_log"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest>=2.9.0
 docker-py
 backoff
+docker-compose==1.5.2

--- a/test_screencast.py
+++ b/test_screencast.py
@@ -11,7 +11,7 @@ def _get_request(example_container):
     return requests.get("http://{url}/".format(url=example_container))
 
 
-def test__works(example_container):
+def test__example_service(example_container):
     result = _get_request(example_container)
     assert result.json() == {"status": "alive"}
 


### PR DESCRIPTION
Many folks have asked 'why not use docker compose' in response
to the examples that use pytest fixtures, and docker-compose is
often appropriate so we'll include an example of this as well
(both pytest fixtures and docker-py still come in handy!)

Not the cleanest use of parameterized fixtures, but I couldn't
find anything cleaner (maybe @mtomwing will have some better ideas)
